### PR TITLE
Use six.text_type instead of unicode

### DIFF
--- a/sluggable/fields.py
+++ b/sluggable/fields.py
@@ -105,7 +105,7 @@ class SluggableField(models.SlugField):
         if value is None:
             return None
 
-        return unicode(value)
+        return six.text_type(value)
 
     def south_field_triple(self):
         "Returns a suitable description of this field for South."


### PR DESCRIPTION
`unicode` is Python 2 only.

Also, please merge `with_unique_with` to master.
